### PR TITLE
Feature/corruption resistance

### DIFF
--- a/alembic/versions/a85f1df955ea_added_corruption_resistance_column.py
+++ b/alembic/versions/a85f1df955ea_added_corruption_resistance_column.py
@@ -1,0 +1,26 @@
+"""Added corruption resistance column
+
+Revision ID: a85f1df955ea
+Revises: 62ddfe32b7db
+Create Date: 2020-06-17 15:59:09.833867
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a85f1df955ea'
+down_revision = '62ddfe32b7db'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('characters', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cloak_resistance', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('characters', schema=None) as batch_op:
+        batch_op.drop_column('cloak_resistance')

--- a/altaudit/audit.py
+++ b/altaudit/audit.py
@@ -166,7 +166,7 @@ class Audit:
         try:
             characters = session.query(Character).all()
 
-            output = [Section.metadata()]
+            output = [Section.metadata(characters[0].region_name)]
             for character in characters:
                 logger.debug("%s:%s:%s", character.region_name, character.realm_slug, character.name)
                 try:

--- a/altaudit/models/character.py
+++ b/altaudit/models/character.py
@@ -109,6 +109,7 @@ CHARACTER_HEADER_FIELDS = {
 
     # Cloak Rank
     'cloak_rank' : 'Column(Integer)',
+    'cloak_resistance' : 'Column(Integer)',
 
     # Azerite Info
     'hoa_level' : 'Column(Integer)',

--- a/altaudit/sections/items.py
+++ b/altaudit/sections/items.py
@@ -35,6 +35,7 @@ def items(character, profile, db_session, api):
     if cloak and cloak['name'] == "Ashjra'kamas, Shroud of Resolve":
         try:
             character.cloak_rank = int(re.match(r'Rank ([0-9]+)', cloak['name_description']['display_string']).group(1))
+            character.cloak_resistance = int(next((stat['value'] for stat in cloak['stats'] if stat['type']['type'] == 'CORRUPTION_RESISTANCE'), 0))
         except (KeyError,TypeError):
             pass
 

--- a/altaudit/sections/metadata.py
+++ b/altaudit/sections/metadata.py
@@ -4,6 +4,17 @@ from ..utility import Utility
 from ..version import VERSION, WOW_PATCH
 from .raids import VALID_RAIDS
 
-def metadata():
+def metadata(region):
     raids = '|'.join(['{}+{}'.format(raid['name'], '_'.join([boss['name'] for boss in raid['encounters']])) for raid in VALID_RAIDS])
-    return [Utility.refresh_time, VERSION, WOW_PATCH, raids]
+
+    max_corruption_resist = 0
+
+    if Utility.year[region] > 2020:
+        max_corruption_resist = 125
+
+    max_corruption_resist = ((Utility.week[region] - 12) * 3) + 50
+
+    if max_corruption_resist > 125:
+        max_corruption_resist = 125
+
+    return [Utility.refresh_time, VERSION, WOW_PATCH, raids, max_corruption_resist]

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -466,7 +466,7 @@ class TestAuditRefresh:
     def test_refresh_returns_list(self, mock_process_blizzard, mock_process_raiderio, mock_update_snapshots, mock_serialize):
         result = self.audit.refresh(datetime.datetime)
 
-        assert result == [Section.metadata(), mock_serialize.return_value]
+        assert result == [Section.metadata('us'), mock_serialize.return_value]
 
     @pytest.mark.skip(reason='TODO')
     def test_refresh_commits_changes(self, mock_process_blizzard, mock_process_raiderio, mock_update_snapshots, mock_serialize):

--- a/test/test_sections/test_items.py
+++ b/test/test_sections/test_items.py
@@ -161,7 +161,7 @@ def test_cloak_not_ashjrakamas(default_items_response):
     Section.items(jack, default_items_response, None, None)
     assert jack.cloak_rank == None
 
-def test_cloak_ashjrakamas(default_items_response):
+def test_cloak_ashjrakamas_rank(default_items_response):
     jack = Character('jack')
     cloak = next(item for item in default_items_response['equipment']['equipped_items'] if item['slot']['type'] == 'BACK')
     cloak['name'] = "Ashjra'kamas, Shroud of Resolve"
@@ -169,7 +169,15 @@ def test_cloak_ashjrakamas(default_items_response):
 
     Section.items(jack, default_items_response, None, None)
     assert jack.cloak_rank == 12
-    pass
+
+def test_cloak_ashjrakamas_resistance(default_items_response):
+    jack = Character('jack')
+    cloak = next(item for item in default_items_response['equipment']['equipped_items'] if item['slot']['type'] == 'BACK')
+    cloak['name'] = "Ashjra'kamas, Shroud of Resolve"
+    cloak['name_description'] = { 'display_string' : "Rank 12" }
+    cloak['stats'] = [{'type' : {'type' : 'CORRUPTION_RESISTANCE'}, 'value' : 86}]
+
+    Section.items(jack, default_items_response, None, None)
 
 def test_tabard_ignored(default_items_response):
     jack = Character('jack')

--- a/test/test_sections/test_metadata.py
+++ b/test/test_sections/test_metadata.py
@@ -13,13 +13,20 @@ def test_metadata_timestamp():
 
     Utility.set_refresh_timestamp(now)
 
-    assert Section.metadata()[0] == now
+    assert Section.metadata('us')[0] == now
 
 def test_metadata_software_version():
-    assert Section.metadata()[1] == VERSION
+    assert Section.metadata('us')[1] == VERSION
 
 def test_metadata_wow_patch():
-    assert Section.metadata()[2] == WOW_PATCH
+    assert Section.metadata('us')[2] == WOW_PATCH
 
 def test_metadata_raids():
-    assert Section.metadata()[3] == "Uldir+Taloc_MOTHER_Fetid Devourer_Zek'voz, Herald of N'zoth_Vectis_Zul, Reborn_Mythrax the Unraveler_G'huun|Battle of Dazar'alor+Champion of the Light_Grong_Jadefire Masters_Opulence_Conclave of the Chosen_King Rastakhan_Mekkatorque_Stormwall Blockade_Lady Jaina Proudmoore|Crucible of Storms+The Restless Cabal_Uu'nat, Harbinger of the Void|The Eternal Palace+Abyssal Commander Sivara_Radiance of Azshara_Blackwater Behemoth_Lady Ashvane_Orgozoa_The Queen's Court_Za'qul_Queen Azshara|Ny'alotha, the Waking City+Wrathion_Maut_The Prophet Skitra_Dark Inquisitor Xanesh_The Hivemind_Shad'har the Insatiable_Drest'agath_Vexiona_Ra-den the Despoiled_Il'gynoth, Corruption Reborn_Carapace of N'Zoth_N'Zoth the Corruptor"
+    assert Section.metadata('us')[3] == "Uldir+Taloc_MOTHER_Fetid Devourer_Zek'voz, Herald of N'zoth_Vectis_Zul, Reborn_Mythrax the Unraveler_G'huun|Battle of Dazar'alor+Champion of the Light_Grong_Jadefire Masters_Opulence_Conclave of the Chosen_King Rastakhan_Mekkatorque_Stormwall Blockade_Lady Jaina Proudmoore|Crucible of Storms+The Restless Cabal_Uu'nat, Harbinger of the Void|The Eternal Palace+Abyssal Commander Sivara_Radiance of Azshara_Blackwater Behemoth_Lady Ashvane_Orgozoa_The Queen's Court_Za'qul_Queen Azshara|Ny'alotha, the Waking City+Wrathion_Maut_The Prophet Skitra_Dark Inquisitor Xanesh_The Hivemind_Shad'har the Insatiable_Drest'agath_Vexiona_Ra-den the Despoiled_Il'gynoth, Corruption Reborn_Carapace of N'Zoth_N'Zoth the Corruptor"
+
+def test_metadata_corruption_resist_basic():
+    now = datetime.datetime(2020, 6, 17, 16)
+
+    Utility.set_refresh_timestamp(now)
+
+    assert Section.metadata('us')[4] == 89

--- a/test/test_sections/test_metadata.py
+++ b/test/test_sections/test_metadata.py
@@ -30,3 +30,17 @@ def test_metadata_corruption_resist_basic():
     Utility.set_refresh_timestamp(now)
 
     assert Section.metadata('us')[4] == 89
+
+def test_metadata_corruption_resist_same_year_after_max():
+    now = datetime.datetime(2020, 10, 17, 16)
+
+    Utility.set_refresh_timestamp(now)
+
+    assert Section.metadata('us')[4] == 125
+
+def test_metadata_corruption_resist_next_year():
+    now = datetime.datetime(2021, 10, 17, 16)
+
+    Utility.set_refresh_timestamp(now)
+
+    assert Section.metadata('us')[4] == 125


### PR DESCRIPTION
Added legendary cloak corruption resistance, as well as current max resistance to metadata (the metadata uses the region of the first character in the list, so it might be a bit janky for multi-region sheets, but those are probably weird anyway).